### PR TITLE
make Stringer become a Serializable object

### DIFF
--- a/android-plist-parser-app/src/com/longevitysoft/android/util/Stringer.java
+++ b/android-plist-parser-app/src/com/longevitysoft/android/util/Stringer.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.Serializable;
 
 /**
  * Wrapper for {@link StringBuilder}.
@@ -24,7 +25,7 @@ import java.io.Reader;
  * @author fbeachler
  * 
  */
-public class Stringer {
+public class Stringer implements Serializable {
 
 	private StringBuilder builder;
 


### PR DESCRIPTION
Since `Stringer` is a wrapper for `StringBuilder`, it makes sense to `Stringer` to be `Serializable`. This makes it possible to serialize `Stringer`.
